### PR TITLE
add a declare file so that this module can be used for typescript projects.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'qcloudsms_js';


### PR DESCRIPTION
I am using typescript in our projects. And we also want to use Tencent short message service. To use the SDK in our project, we have to manually add this declare file, otherwise there will be compiler issues.  

In addition, it's common for a npm modules to include an index.d.ts file so that they can be applied in typescript projects as well.  Hope we can make it in this package as well. 

Thanks.